### PR TITLE
Delete endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -184,6 +184,22 @@ app.patch('/api/v1/palette/:id', async (request, response) => {
   }
 });
 
+app.delete('/api/v1/projects/:id', async (request, response) => {
+  const { id } = request.params;
+
+  try {
+    const project = await database('projects').where('id', id).del();
+
+    if (project > 0) {
+      return response.status(200).json()
+    } else {
+      response.status(404).json({ error: 'No project found' })
+    }
+  } catch (error) {
+    response.status(500).json(error)
+  }
+});
+
 app.delete('/api/v1/palette/:id', async (request, response) => {
   const { id } = request.params;
 
@@ -203,11 +219,5 @@ app.delete('/api/v1/palette/:id', async (request, response) => {
     response.status(500).json(error);
   }
 });
-
-// delete - /api/projects/:id
-// delete project (CASCADE to delete all pallets)
-
-// delete - /api/pallet/:id
-// delete a pallet from a project
 
 module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -256,7 +256,7 @@ describe('Server', () => {
     });
   });
 
-  describe.skip('DELETE /api/v1/projects/:id', () => {
+  describe('DELETE /api/v1/projects/:id', () => {
     it('should return a 200 status code and remove project from database', async () => {
       const currentProjects = await database('projects').select();
       const projectToDelete = await database('projects').first();
@@ -277,7 +277,7 @@ describe('Server', () => {
 
     it('should return a 404 status code and an error message when there is no project found', async () => {
       const response = await request(app).delete('/api/v1/projects/-1');
-      const expectedMessage = 'No project with this id can be found';
+      const expectedMessage = 'No project found';
 
       expect(response.status).toBe(404);
       expect(response.body.error).toBe(expectedMessage);

--- a/app.test.js
+++ b/app.test.js
@@ -101,7 +101,7 @@ describe('Server', () => {
     });
   });
 
-  describe.skip('POST /api/v1/projects', () => {
+  describe('POST /api/v1/projects', () => {
     it('should return a 201 status code and add a new project to the database', async () => {
       const newProject = { project_name: 'Drag Nation' };
 


### PR DESCRIPTION
## What does this PR do?
This pull request adds an endpoint to DELETE a project and all of its palettes.

### Where should the reviewer start?
Line 187 in the `app.js` file.

#### How should this be manually tested?
In Postman make a request to DELETE an existing project using the url `api/v1/projects/:id`. Then make a GET request to projects to confirm it has indeed be deleted, finally make a GET request to get all palettes for that project and there should be an error. One could also check in their terminal with the commands: `psql` => `SELECT * FROM palettes;`

#### Any background context you want to provide?


#### What are the relevant tickets?
Closes #16 

#### Screenshots (if appropriate)


#### Additional Notes