### PR TITLE
Add query param GET endpoint to allow for searching by palette name

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,6 +75,24 @@ app.get('/api/v1/palette/:id', async (request, response) => {
   }
 });
 
+app.get(`/api/v1/search`, async (request, response) => {
+  try {
+    const palette_name = request.query.palette_name
+    const palettes = await database('palettes').select();
+    const searchResults = palettes.filter(result => {
+      return result.palette_name == palette_name
+    })
+
+    if (!searchResults) {
+      response.status(404).json(`No palettes with ${palette_name} can be found. Please try again.`)
+    } else {
+      response.status(200).json({ searchResults })
+    }
+  } catch (error) {
+    response.status(500).json({ error: 'Internal server error' })
+  }
+});
+
 app.post('/api/v1/projects', async (request, response) => {
   const project = request.body;
 
@@ -203,11 +221,5 @@ app.delete('/api/v1/palette/:id', async (request, response) => {
     response.status(500).json(error);
   }
 });
-
-// delete - /api/projects/:id
-// delete project (CASCADE to delete all pallets)
-
-// delete - /api/pallet/:id
-// delete a pallet from a project
 
 module.exports = app;

--- a/data/data.js
+++ b/data/data.js
@@ -21,7 +21,7 @@ const data = {
       palette_name: 'Option 2',
       color_1: '#D8E2DC',
       color_2: '#FFE5D9',
-      color_3: 'D1A6AE',
+      color_3: '#D1A6AE',
       color_4: '#9D8189',
       color_5: '#432F32',
       project_name: 'Portfolio Website'


### PR DESCRIPTION
Co-authored-by: Vanessa Randall <vanessalrandall@gmail.com>

## What does this PR do?
Adds a query param endpoint to allows to search for palettes by name.

### Where should the reviewer start?
Lines 78-95 in `app.js`.

#### How should this be manually tested?
In postman to a GET request with the URL `http://localhost:3000/api/v1/search?palette_name=Ocean` and the response should be the following:

```javascript
{
    "searchResults": [
        {
            "id": 7,
            "palette_name": "Ocean",
            "color_1": "#020216",
            "color_2": "#00042B",
            "color_3": "#001E64",
            "color_4": "#006CAD",
            "color_5": "#00C0FA",
            "project_id": 6
        }
    ]
}
```

#### Any background context you want to provide?


#### What are the relevant tickets?
Closes #29 

#### Screenshots (if appropriate)


#### Additional Notes
Nice collab today, Vanessa! That one commit took some effort, flexibility, and problem-solving and we did the thing.