### PR TITLE
Generate a pass test to GET all palettes

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,19 @@ app.get('/api/v1/projects', async (request, response) => {
   }
 });
 
+app.get('/api/v1/palettes', async (request, response) => {
+  try {
+    const palettes = await database('palettes').select();
+    if (palettes.length) {
+      response.status(200).json(palettes);
+    } else {
+      response.status(404).status({ error: 'Could not get palettes'})
+    }
+  } catch (error) {
+    response.status(500).json({ error: 'Internal server error' })
+  }
+})
+
 app.get('/api/v1/projects/:id', async (request, response) => {
   const { id } = request.params;
 

--- a/app.test.js
+++ b/app.test.js
@@ -31,6 +31,19 @@ describe('Server', () => {
     });
   });
 
+  describe('GET /api/v1/palettes', () => {
+    it('should return a 200 status code and all of the palettes', async () => {
+      const expectedPalettes = await database('palettes').select();
+
+      const response = await request(app).get('/api/v1/palettes');
+      const palettes = response.body;
+      expect(response.status).toBe(200);
+      expect(palettes[0].palette_name).toEqual(
+        expectedPalettes[0].palette_name
+      )
+    })
+  });
+
   describe('GET /api/v1/projects/:id', () => {
     it('should return a 200 status code and the project with the matching id', async () => {
       const expectedProject = await database('projects').first();


### PR DESCRIPTION
## What does this PR do?
This PR simply adds a GET endpoint to get all palettes.

### Where should the reviewer start?
`app.js` - lines 29-40 & `app.test.js` - lines 34-45

#### How should this be manually tested?
Run the test suite and try a GET request in postman using the url `/api/v1/palettes`

#### Any background context you want to provide?


#### What are the relevant tickets?
Closes #56 

#### Screenshots (if appropriate)
<img width="479" alt="Screen Shot 2019-12-10 at 4 36 22 PM" src="https://user-images.githubusercontent.com/48900496/70578536-43bafd00-1b6b-11ea-957e-683edcc50e62.png">

#### Additional Notes